### PR TITLE
Fix quote handling in pre/post exec commands

### DIFF
--- a/src/backup.sh
+++ b/src/backup.sh
@@ -52,16 +52,13 @@ if [ "$CONTAINERS_TO_STOP_TOTAL" != "0" ]; then
 fi
 
 if [ -S "$DOCKER_SOCK" ]; then
-  TEMPFILE="$(mktemp)"
-  docker ps \
-    --filter "label=docker-volume-backup.exec-pre-backup" $CUSTOM_LABEL \
-    --format '{{.ID}} {{.Label "docker-volume-backup.exec-pre-backup"}}' \
-    > "$TEMPFILE"
-  while read line; do
-    info "Pre-exec command: $line"
-    docker exec $line
-  done < "$TEMPFILE"
-  rm "$TEMPFILE"
+  for id in $(docker ps --filter label=docker-volume-backup.exec-pre-backup $CUSTOM_LABEL --format '{{.ID}}'); do
+    name="$(docker ps --filter id=$id --format '{{.Names}}')"
+    cmd="$(docker ps --filter id=$id --format '{{.Label "docker-volume-backup.exec-pre-backup"}}')"
+    info "Pre-exec command for: $name"
+    echo docker exec $id $cmd # echo the command we're using, for debuggability
+    eval docker exec $id $cmd
+  done
 fi
 
 info "Creating backup"
@@ -79,16 +76,13 @@ if [ ! -z "$GPG_PASSPHRASE" ]; then
 fi
 
 if [ -S "$DOCKER_SOCK" ]; then
-  TEMPFILE="$(mktemp)"
-  docker ps \
-    --filter "label=docker-volume-backup.exec-post-backup" $CUSTOM_LABEL \
-    --format '{{.ID}} {{.Label "docker-volume-backup.exec-post-backup"}}' \
-    > "$TEMPFILE"
-  while read line; do
-    info "Post-exec command: $line"
-    docker exec $line
-  done < "$TEMPFILE"
-  rm "$TEMPFILE"
+  for id in $(docker ps --filter label=docker-volume-backup.exec-post-backup $CUSTOM_LABEL --format '{{.ID}}'); do
+    name="$(docker ps --filter id=$id --format '{{.Names}}')"
+    cmd="$(docker ps --filter id=$id --format '{{.Label "docker-volume-backup.exec-post-backup"}}')"
+    info "Post-exec command for: $name"
+    echo docker exec $id $cmd # echo the command we're using, for debuggability
+    eval docker exec $id $cmd
+  done
 fi
 
 if [ "$CONTAINERS_TO_STOP_TOTAL" != "0" ]; then

--- a/test/pre-post-backup-exec/docker-compose.yml
+++ b/test/pre-post-backup-exec/docker-compose.yml
@@ -1,15 +1,14 @@
 version: "3"
 
 services:
-
   database:
     image: influxdb:1.5.4
     volumes:
       - influxdb-data:/var/lib/influxdb
       - influxdb-temp:/tmp/influxdb
     labels:
-      - docker-volume-backup.exec-pre-backup=influxd backup -portable /tmp/influxdb
-      - docker-volume-backup.exec-post-backup=rm -rfv /tmp/influxdb
+      - docker-volume-backup.exec-pre-backup=bash -c 'influxd backup -portable /tmp/influxdb'
+      - docker-volume-backup.exec-post-backup=rm -rfv /tmp/influxdb/*
 
   backup:
     build: ../..


### PR DESCRIPTION
Previously, if the pre/post exec commands contained quotes, they wouldn't work.

Now they do; see tests for an example.