### PR TITLE
Request BACKUP_CUSTOM_LABEL when stop containers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,12 @@ services:
     labels:
       # Adding this label means this container should be stopped while it's being backed up:
       - "docker-volume-backup.stop-during-backup=true"
+      - "grafana"
 
   backup:
     image: jareware/docker-volume-backup
     environment:
+      BACKUP_CUSTOM_LABEL: "grafana"
       AWS_S3_BUCKET_NAME: my-backup-bucket      # S3 bucket which you own, and already exists
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}   # Read AWS secrets from environment (or a .env file)
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}

--- a/test/stopping-containers-while-backing-up/docker-compose.yml
+++ b/test/stopping-containers-while-backing-up/docker-compose.yml
@@ -10,11 +10,13 @@ services:
       - grafana-data:/var/lib/grafana
     labels:
       - "docker-volume-backup.stop-during-backup=true"
+      - "grafana"
 
   backup:
     build: ../..
     environment:
       BACKUP_CRON_EXPRESSION: "* * * * *"
+      BACKUP_CUSTOM_LABEL: "grafana"
       AWS_S3_BUCKET_NAME: docker-volume-backup-test-bucket
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
Currently, there is a bug or, let's say, undesirable behavior when `docker.sock` is mounted. This will fix it:

When `docker.sock` is mounted (e.g., if you like to trigger `docker-rotate-backups` by means of `POST_COMMAND`) and `BACKUP_CUSTOM_LABEL` is not set, all containers that have the label `docker-volume-backup.stop-during-backup=true` will be stopped - regardless if they have another tag or not. This may be not desired.

With this pull request, we simply request `BACKUP_CUSTOM_LABEL` to be set in order to stop and start containers.