### PR TITLE
Lightweight docker install (docker-cli) (requires >=18.09)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,12 @@ RUN rm -rf /var/lib/apt/lists/*
 # ...but only for architectures that support it (see https://github.com/futurice/docker-volume-backup/issues/29)
 RUN if [ $(uname -m) = "aarch64" ] || [ $(uname -m) = "x86_64" ] ; then curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" && unzip -q awscliv2.zip && ./aws/install -i /usr/bin -b /usr/bin && rm -rf ./aws awscliv2.zip && aws --version ; fi
 
+# Install Docker binary
+# a) get.docker.com
 # https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#install-using-the-convenience-script
-RUN curl -fsSL get.docker.com -o get-docker.sh
-RUN sh get-docker.sh
+# RUN curl -fsSL get.docker.com | sh
+# b) Borrow it from Official Docker container
+COPY --from=docker:latest /usr/local/bin/docker /usr/local/bin/
 
 COPY ./src/entrypoint.sh /root/
 COPY ./src/backup.sh /root/


### PR DESCRIPTION
**Lightweight docker install (docker-cli) (requires >=18.09)**

docker-volume-backup only requires docker-cli to operate.
This commit borrows the precompiled cli binary from Docker's official image
instead of the one provided by Docker's apt repository.
Therefore, apt-get is neither required.

More info at:
https://stackoverflow.com/questions/38675925/is-it-possible-to-install-only-the-docker-cli-and-not-the-daemon

---

This PR will remove dockerd daemon from the container and therefore will reduce image size about **488MB**
- jareware/docker-volume-backup   2.6.0                  e1cc3c58adff   5 weeks ago         **820MB**
- varribas/docker-volume-backup   latest                 5fc2e791e9ef   About an hour ago   **332MB**

Testing:

- current
```
docker run --rm -i --entrypoint=bash -v /var/run/docker.sock:/var/run/docker.sock:ro jareware/docker-volume-backup:2.6.0<<EOF
which dockerd
which docker
docker --version
docker ps
EOF
```
```
/usr/bin/dockerd
/usr/bin/docker
Docker version 20.10.12, build e91ed57
CONTAINER ID   IMAGE                                 COMMAND   CREATED        STATUS                  PORTS     NAMES
e6f8c398e38a   jareware/docker-volume-backup:2.6.0   "bash"    1 second ago   Up Less than a second             focused_ramanujan
```

- proposal
```
docker run --rm -i --entrypoint=bash -v /var/run/docker.sock:/var/run/docker.sock:ro varribas/docker-volume-backup<<EOF
which dockerd
which docker
docker --version
docker ps
EOF
```
```
Docker version 20.10.12, build e91ed57
CONTAINER ID   IMAGE                           COMMAND   CREATED        STATUS                  PORTS     NAMES
98b00a7020aa   varribas/docker-volume-backup   "bash"    1 second ago   Up Less than a second             trusting_moore
```

*Notice that both versions of docker (the one by Ubuntu 18.04 and from this approach) are the same ;)*

